### PR TITLE
Fixed incorrect tuple unpacking in check_cyclic

### DIFF
--- a/numericals.py
+++ b/numericals.py
@@ -702,7 +702,7 @@ def check_perp(points: list[Point]) -> bool:
 
 def check_cyclic(points: list[Point]) -> bool:
   points = list(set(points))
-  (a, b, c), *ps = points
+  (a, b, c, *ps) = points
   circle = Circle(p1=a, p2=b, p3=c)
   for d in ps:
     if not close_enough(d.distance(circle.center), circle.radius):


### PR DESCRIPTION
This PR fixes a typo in `numericals.py`. 
 
To reproduce the issue, use this problem:
`
a b c = triangle a b c; o = circle o a b c; t = on_tline t a o a, on_line t b c; p = midpoint p t a; e = midpoint e t c ? cyclic a p e b
`