### PR TITLE
Optimization with Python comprehensions

### DIFF
--- a/alphageometry.py
+++ b/alphageometry.py
@@ -307,7 +307,7 @@ def translate_constrained_to_constructive(
     return 'on_aline', [a, x, b, c, y, d]
 
   elif name in ['cyclic', 'O']:
-    a, b, c = [x for x in args if x != point]
+    a, b, c = (x for x in args if x != point)
     return 'on_circum', [point, a, b, c]
 
   return name, args
@@ -478,8 +478,7 @@ class BeamQueue:
       self.queue[min_idx] = (val, node)
 
   def __iter__(self):
-    for val, node in self.queue:
-      yield val, node
+    yield from self.queue
 
   def __len__(self) -> int:
     return len(self.queue)

--- a/ar.py
+++ b/ar.py
@@ -76,7 +76,7 @@ def frac_string(f: frac) -> str:
 
 
 def hashed(e: dict[str, float]) -> tuple[tuple[str, float], ...]:
-  return tuple(sorted(list(e.items())))
+  return tuple(sorted(e.items()))
 
 
 def is_zero(e: dict[str, float]) -> bool:
@@ -632,7 +632,7 @@ class AngleTable(GeometricTable):
   ) -> None:
     """Add the inequality d1-d2=d3-d4."""
     # Use string as variables.
-    l1, l2, l3, l4 = [d._obj.num for d in [d1, d2, d3, d4]]  # pylint: disable=protected-access
+    l1, l2, l3, l4 = (d._obj.num for d in [d1, d2, d3, d4])  # pylint: disable=protected-access
     d1, d2, d3, d4 = self.get_name([d1, d2, d3, d4])
     ang1 = {d1: 1, d2: -1}
     ang2 = {d3: 1, d4: -1}
@@ -708,8 +708,7 @@ class DistanceTable(GeometricTable):
     return super().add_eq4(p1, p2, p3, p4, dep)
 
   def get_all_eqs_and_why(self) -> Generator[Any, None, None]:
-    for x in super().get_all_eqs_and_why(True):
-      yield x
+    yield from super().get_all_eqs_and_why(True)
 
     # Now we figure out all the const ratios.
     h2pairs = defaultdict(list)

--- a/dd.py
+++ b/dd.py
@@ -373,7 +373,7 @@ def match_eqangle_ncoll_cyclic(
 ) -> Generator[dict[str, gm.Point], None, None]:
   """Match eqangle6 P A P B Q A Q B, ncoll P Q A B => cyclic A B P Q."""
   for l1, l2, l3, l4 in g.all_eqangles_distinct_linepairss():
-    if len(set([l1, l2, l3, l4])) < 4:
+    if len({l1, l2, l3, l4}) < 4:
       continue  # they all must be distinct.
 
     p1s = l1.neighbors(gm.Point, return_set=True)
@@ -393,7 +393,7 @@ def match_eqangle_ncoll_cyclic(
     b = intersect1(p2s, p4s)
     if not b:
       continue
-    if len(set([a, b, p, q])) < 4:
+    if len({a, b, p, q}) < 4:
       continue
 
     if not g.check_ncoll([a, b, p, q]):
@@ -488,7 +488,7 @@ def match_cong_cong_cong_ncoll_contri(
   for a, b, p, q in g_matcher('cong'):
     for c in g.type2nodes[gm.Point]:
       for r in g.type2nodes[gm.Point]:
-        if any([x in record for x in rotate_simtri(a, b, c, p, q, r)]):
+        if any(x in record for x in rotate_simtri(a, b, c, p, q, r)):
           continue
         if not g.check_ncoll([a, b, c]):
           continue
@@ -552,7 +552,7 @@ def match_eqratio6_eqangle6_ncoll_simtri(
   for b, a, b, c, q, p, q, r in enums:  # pylint: disable=redeclared-assigned-name,unused-variable
     if (a, b, c) == (p, q, r):
       continue
-    if any([x in record for x in rotate_simtri(a, b, c, p, q, r)]):
+    if any(x in record for x in rotate_simtri(a, b, c, p, q, r)):
       continue
     if not g.check_ncoll([a, b, c]):
       continue
@@ -578,7 +578,7 @@ def match_eqangle6_eqangle6_ncoll_simtri(
   for b, a, b, c, q, p, q, r in enums:  # pylint: disable=redeclared-assigned-name,unused-variable
     if (a, b, c) == (p, q, r):
       continue
-    if any([x in record for x in rotate_simtri(a, b, c, p, q, r)]):
+    if any(x in record for x in rotate_simtri(a, b, c, p, q, r)):
       continue
     if not g.check_eqangle([c, a, c, b, r, p, r, q]):
       continue
@@ -602,7 +602,7 @@ def match_eqratio6_eqratio6_ncoll_simtri(
   for b, a, b, c, q, p, q, r in enums:  # pylint: disable=redeclared-assigned-name,unused-variable
     if (a, b, c) == (p, q, r):
       continue
-    if any([x in record for x in rotate_simtri(a, b, c, p, q, r)]):
+    if any(x in record for x in rotate_simtri(a, b, c, p, q, r)):
       continue
     if not g.check_eqratio([c, a, c, b, r, p, r, q]):
       continue
@@ -626,7 +626,7 @@ def match_eqangle6_eqangle6_ncoll_simtri2(
   for b, a, b, c, q, r, q, p in enums:  # pylint: disable=redeclared-assigned-name,unused-variable
     if (a, b, c) == (p, q, r):
       continue
-    if any([x in record for x in rotate_simtri(a, b, c, p, q, r)]):
+    if any(x in record for x in rotate_simtri(a, b, c, p, q, r)):
       continue
     if not g.check_eqangle([c, a, c, b, r, q, r, p]):
       continue
@@ -641,8 +641,7 @@ def match_eqangle6_eqangle6_ncoll_simtri2(
 def rotate_contri(
     a: gm.Point, b: gm.Point, c: gm.Point, x: gm.Point, y: gm.Point, z: gm.Point
 ) -> Generator[tuple[gm.Point, ...], None, None]:
-  for p in [(b, a, c, y, x, z), (x, y, z, a, b, c), (y, x, z, b, a, c)]:
-    yield p
+  yield from [(b, a, c, y, x, z), (x, y, z, a, b, c), (y, x, z, b, a, c)]
 
 
 def match_eqangle6_eqangle6_ncoll_cong_contri(
@@ -659,7 +658,7 @@ def match_eqangle6_eqangle6_ncoll_cong_contri(
       continue
     if (a, b, c) == (p, q, r):
       continue
-    if any([x in record for x in rotate_contri(a, b, c, p, q, r)]):
+    if any(x in record for x in rotate_contri(a, b, c, p, q, r)):
       continue
     if not g.check_eqangle([c, a, c, b, r, p, r, q]):
       continue
@@ -686,7 +685,7 @@ def match_eqratio6_eqratio6_ncoll_cong_contri(
       continue
     if (a, b, c) == (p, q, r):
       continue
-    if any([x in record for x in rotate_contri(a, b, c, p, q, r)]):
+    if any(x in record for x in rotate_contri(a, b, c, p, q, r)):
       continue
     if not g.check_eqratio([c, a, c, b, r, p, r, q]):
       continue
@@ -713,7 +712,7 @@ def match_eqangle6_eqangle6_ncoll_cong_contri2(
       continue
     if (a, b, c) == (p, q, r):
       continue
-    if any([x in record for x in rotate_contri(a, b, c, p, q, r)]):
+    if any(x in record for x in rotate_contri(a, b, c, p, q, r)):
       continue
     if not g.check_eqangle([c, a, c, b, r, q, r, p]):
       continue
@@ -848,8 +847,7 @@ def try_to_map(
     if fail:
       continue
 
-    for m in try_to_map(clause_enum[1:], mpcpy):
-      yield m
+    yield from try_to_map(clause_enum[1:], mpcpy)
 
 
 def match_generic(
@@ -985,7 +983,7 @@ def match_all_theorems(
   theorem2mappings = {}
 
   # Step 1: list all matches
-  for _, theorem in theorems.items():
+  for theorem in theorems.values():
     name = theorem.name
     if name.split('_')[-1] in [
         'acompute',

--- a/geometry.py
+++ b/geometry.py
@@ -432,7 +432,7 @@ def line_of_and_why(
   """Why points are collinear."""
   for l0 in get_lines_thru_all(*points):
     for l in l0.equivs():
-      if all([p in l.edge_graph for p in points]):
+      if all(p in l.edge_graph for p in points):
         x, y = l.points
         colls = list({x, y} | set(points))
         # if len(colls) < 3:
@@ -459,7 +459,7 @@ def circle_of_and_why(
   """Why points are concyclic."""
   for c0 in get_circles_thru_all(*points):
     for c in c0.equivs():
-      if all([p in c.edge_graph for p in points]):
+      if all(p in c.edge_graph for p in points):
         cycls = list(set(points))
         why = c.why_cyclic(cycls, level)
         if why is not None:
@@ -474,7 +474,7 @@ def name_map(struct: Any) -> Any:
   elif isinstance(struct, tuple):
     return tuple([name_map(x) for x in struct])
   elif isinstance(struct, set):
-    return set([name_map(x) for x in struct])
+    return {name_map(x) for x in struct}
   elif isinstance(struct, dict):
     return {name_map(x): name_map(y) for x, y in struct.items()}
   else:

--- a/lm_inference.py
+++ b/lm_inference.py
@@ -95,7 +95,7 @@ class LanguageModelInference:
 
   def encode_list(self, inputs_strs: list[str]) -> list[int]:
     result = [self.vocab.encode(x) for x in inputs_strs]
-    assert all([len(x) == 1 for x in result]), [
+    assert all(len(x) == 1 for x in result), [
         self.decode(x) for x in result if len(x) != 1
     ]
     return [x[0] for x in result]

--- a/numericals.py
+++ b/numericals.py
@@ -333,9 +333,9 @@ class HalfLine(Line):
       exclude += [obj.hole]
 
     a, b = line_circle_intersection(self.line, obj)
-    if any([a.close(x) for x in exclude]):
+    if any(a.close(x) for x in exclude):
       return b
-    if any([b.close(x) for x in exclude]):
+    if any(b.close(x) for x in exclude):
       return a
 
     v = self.head - self.tail
@@ -379,7 +379,7 @@ def _perpendicular_bisector(p1: Point, p2: Point) -> Line:
 def same_sign(
     a: Point, b: Point, c: Point, d: Point, e: Point, f: Point
 ) -> bool:
-  a, b, c, d, e, f = map(lambda p: p.sym, [a, b, c, d, e, f])
+  a, b, c, d, e, f = (p.sym for p in [a, b, c, d, e, f])
   ab, cb = a - b, c - b
   de, fe = d - e, f - e
   return (ab.x * cb.y - ab.y * cb.x) * (de.x * fe.y - de.y * fe.x) > 0
@@ -1064,7 +1064,7 @@ def highlight(
     color2: Any,
 ) -> None:
   """Draw highlights."""
-  args = list(map(lambda x: x.num if isinstance(x, gm.Point) else x, args))
+  args = [x.num if isinstance(x, gm.Point) else x for x in args]
 
   if name == 'cyclic':
     a, b, c, d = args
@@ -1311,10 +1311,10 @@ def reduce(
     if isinstance(result, Point):
       return [result]
     a, b = result
-    a_close = any([a.close(x) for x in existing_points])
+    a_close = any(a.close(x) for x in existing_points)
     if a_close:
       return [b]
-    b_close = any([b.close(x) for x in existing_points])
+    b_close = any(b.close(x) for x in existing_points)
     if b_close:
       return [a]
     return [np.random.choice([a, b])]

--- a/problem.py
+++ b/problem.py
@@ -193,10 +193,7 @@ class Problem:
   def translate(self) -> Problem:  # to single-char point names
     """Translate point names into alphabetical."""
     mapping = {}
-    clauses = []
-
-    for clause in self.clauses:
-      clauses.append(clause.translate(mapping))
+    clauses = [clause.translate(mapping) for clause in self.clauses]
 
     if self.goal:
       goal = self.goal.translate(mapping)
@@ -1092,7 +1089,7 @@ def hashed_txt(name: str, args: list[str]) -> tuple[str, ...]:
     return (name, a, b, c)
 
   if name in ['coll', 'cyclic', 'ncoll', 'diff', 'triangle']:
-    return (name,) + tuple(sorted(list(set(args))))
+    return (name,) + tuple(sorted(set(args)))
 
   if name == 'circle':
     x, a, b, c = args

--- a/trace_back.py
+++ b/trace_back.py
@@ -132,7 +132,7 @@ def separate_dependency_difference(
   for con in setup_:
     if con.name == 'ind':
       continue
-    elif any([p not in points for p in con.args if isinstance(p, gm.Point)]):
+    elif any(p not in points for p in con.args if isinstance(p, gm.Point)):
       aux_setup.append(con)
       aux_points.update(
           [p for p in con.args if isinstance(p, gm.Point) and p not in points]
@@ -238,7 +238,7 @@ def collx_to_coll(
   setup = collx_to_coll_setup(setup)
   aux_setup = collx_to_coll_setup(aux_setup)
 
-  con_set = set([p.hashed() for p in setup + aux_setup])
+  con_set = {p.hashed() for p in setup + aux_setup}
   log_, log = log, []
   for prems, cons in log_:
     prem_set = set()
@@ -308,7 +308,7 @@ def shorten_and_shave(
   log, _ = shorten_proof(log, merge_trivials=merge_trivials)
 
   all_prems = sum([list(prems) for prems, _ in log], [])
-  all_prems = set([p.hashed() for p in all_prems])
+  all_prems = {p.hashed() for p in all_prems}
   setup = [d for d in setup if d.hashed() in all_prems]
   aux_setup = [d for d in aux_setup if d.hashed() in all_prems]
   return setup, aux_setup, log


### PR DESCRIPTION
% `ruff --select=C4,PERF,UP027,UP028 --statistics ` # https://docs.astral.sh/ruff
```
19	C419   	[*] Unnecessary list comprehension
 7	UP028  	[*] Replace `yield` over `for` loop with `yield from`
 3	C403   	[*] Unnecessary `list` comprehension (rewrite as a `set` comprehension)
 3	C405   	[*] Unnecessary `list` literal (rewrite as a `set` literal)
 3	C414   	[*] Unnecessary `list` call within `set()`
 3	PERF401	[ ] Use a list comprehension to create a transformed list
 3	UP027  	[*] Replace unpacked list comprehension with a generator expression
 2	C417   	[*] Unnecessary `map` usage (rewrite using a `list` comprehension)
 2	PERF203	[ ] `try`-`except` within a loop incurs performance overhead
 1	C410   	[*] Unnecessary `list` literal passed to `list()` (remove the outer call to `list()`)
 1	C416   	[*] Unnecessary `list` comprehension (rewrite using `list()`)
 1	PERF102	[*] When using only the values of a dict use the `values()` method
```
% `ruff --select=C4,PERF,UP027,UP028 --fix --unsafe-fixes ` # Plus manual fixes for PERF401

% `ruff --select=C4,PERF,UP027,UP028 --statistics`
```
2	PERF203	`try`-`except` within a loop incurs performance overhead
```
% `ruff rule C419`
# unnecessary-comprehension-any-all (C419)

Derived from the **flake8-comprehensions** linter.

Fix is sometimes available.

## What it does
Checks for unnecessary list comprehensions passed to `any` and `all`.

## Why is this bad?
`any` and `all` take any iterators, including generators. Converting a generator to a list
by way of a list comprehension is unnecessary and reduces performance due to the
overhead of creating the list.

For example, compare the performance of `all` with a list comprehension against that
of a generator (~40x faster here):

```console
In [1]: %timeit all([i for i in range(1000)])
8.14 µs ± 25.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit all(i for i in range(1000))
212 ns ± 0.892 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

## Examples
```python
any([x.id for x in bar])
all([x.id for x in bar])
```

Use instead:
```python
any(x.id for x in bar)
all(x.id for x in bar)
```

## Fix safety
This rule's fix is marked as unsafe, as it may occasionally drop comments
when rewriting the comprehension. In most cases, though, comments will be
preserved.