### PR TITLE
Updated run.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
+# Others
+pyvenv.cfg
+share/
+bin/
+ag_ckpt_vocab/
+meliad_lib/

--- a/run.sh
+++ b/run.sh
@@ -17,12 +17,17 @@
 set -e
 set -x
 
-virtualenv -p python3 .
+virtualenv -p python3.10 .
 source ./bin/activate
 
+sudo apt-get install python3.10-tk # temporary solution
+pip install -U pip
 pip install --require-hashes -r requirements.txt
 
-gdown --folder https://bit.ly/alphageometry
+GDRIVE_URL=$(curl -s -L -o /dev/null -w "%{url_effective}" https://bit.ly/alphageometry)
+pip install -U gdown # temporary solution
+echo "Downloading GDrive folder: $GDRIVE_URL"
+gdown --folder "$GDRIVE_URL"
 DATA=ag_ckpt_vocab
 
 MELIAD_PATH=meliad_lib/meliad


### PR DESCRIPTION
- Updated .gitignore
- Updating pip in run.sh
- Updating gdown in run.sh This may be better in the long term.
- Since the requirements.txt is generated using Python 3.10, creating virtualenv is also restricted to this version.
- Extracting bit.ly redirection using curl since gdown does not work.
- **Looks like `tkinter` installation is different for each distribution. Automation of this installation may be quite messy.**